### PR TITLE
Fix uptime seconds check

### DIFF
--- a/check_docker.py
+++ b/check_docker.py
@@ -298,7 +298,7 @@ def check_uptime(container_name, warn, crit, units=None):
     start = datetime.strptime(only_secs, "%Y-%m-%dT%H:%M:%S")
     start = start.replace(tzinfo=timezone.utc)
     now = datetime.now(timezone.utc)
-    uptime = (now - start).seconds
+    uptime = (now - start).total_seconds()
 
     graph_padding = 2
     evaluate_numeric_thresholds(container=container_name, value=uptime, units='s', warn=warn, crit=crit,

--- a/test_check_docker.py
+++ b/test_check_docker.py
@@ -358,6 +358,18 @@ class TestCheckDocker(fake_filesystem_unittest.TestCase):
             check_docker.check_uptime(container_name='container', warn=2, crit=1)
             self.assertEqual(check_docker.rc, check_docker.OK_RC)
 
+    def test_check_uptime4(self):
+        ten = timedelta(days=1, seconds=0)
+        then = datetime.now(tz=timezone.utc) - ten
+        now_string = then.strftime("%Y-%m-%dT%H:%M:%S")
+        now_string += ".0000000000Z"
+        json_results = {
+            'State': {'StartedAt': now_string},
+        }
+        with patch('check_docker.get_url', return_value=json_results):
+            check_docker.check_uptime(container_name='container', warn=2, crit=1)
+            self.assertEqual(check_docker.rc, check_docker.OK_RC)
+
     def test_args_restart(self):
         args = ('--restarts', 'non-default')
         result = check_docker.process_args(args=args)


### PR DESCRIPTION
Uptime check was using timedelta seconds for one day. This made the
checks fail when containers had been running for more than one day but
less seconds than what we expected. This has now been fixed by using
total_seconds instead. A unit test has been added too.