### PR TITLE
Small updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.7-dev"
 install:
   - pip install -r dev_requirements.txt
-  - pip install codeclimate-test-reporter coverage==4.3.4
+  - pip install codeclimate-test-reporter coverage
 # command to run tests
 script:
   - py.test --cov=check_docker

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ check_docker Usage
                          [--memory WARN:CRIT:UNITS] [--status STATUS] [--health]
                          [--uptime WARN:CRIT] [--version]
                          [--insecure-registries INSECURE_REGISTRIES [INSECURE_REGISTRIES ...]]
-                         [--restarts WARN:CRIT]
+                         [--restarts WARN:CRIT] [-V]
 
   Check docker containers.
 
@@ -113,6 +113,8 @@ check_docker Usage
                           Useful when using "--version" with images from
                           insecure registries.
     --restarts WARN:CRIT  Container restart thresholds.
+    -V                    show program's version number and exit
+
 
 check_swarm Usage
 -----------------
@@ -123,7 +125,7 @@ check_swarm Usage
                      [--connection [/<path to>/docker.socket|<ip/host address>:<port>]
                      | --secure-connection [<ip/host address>:<port>]]
                      [--timeout TIMEOUT]
-                     (--swarm | --service SERVICE [SERVICE ...])
+                     (--swarm | --service SERVICE [SERVICE ...]) [-V]
 
   Check docker swarm.
 
@@ -139,17 +141,14 @@ check_swarm Usage
     --service SERVICE [SERVICE ...]
                           One or more RegEx that match the names of the
                           services(s) to check.
-  usage: check_swarm [-h]
-                     [--connection [/<path to>/docker.socket|<ip/host address>:<port>]
-                     | --secure-connection [<ip/host address>:<port>]]
-                     [--timeout TIMEOUT]
-                     (--swarm | --service SERVICE [SERVICE ...])
+    -V                    show program's version number and exit
 
 Gotchas
 -------
 
 -  When using check_docker with older versions of docker (I have seen 1.4 and 1.5) –status only supports ‘running’, ‘restarting’, and ‘paused’.
 -  When using check_docker, if no container is specified, all containers are checked. Some containers may return critcal status if the selected check(s) require a running container.
+-  When using check_docker, --present cannot be used without --containers to indicate what to check the presence of.
 
 .. |Build Status| image:: https://travis-ci.org/timdaman/check_docker.svg?branch=master
    :target: https://travis-ci.org/timdaman/check_docker

--- a/check_docker/check_swarm.py
+++ b/check_docker/check_swarm.py
@@ -16,7 +16,7 @@ __author__ = 'Tim Laurence'
 __copyright__ = "Copyright 2018"
 __credits__ = ['Tim Laurence']
 __license__ = "GPL"
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 
 '''
 nrpe compatible check for docker swarm
@@ -223,6 +223,8 @@ def process_args(args):
                              nargs='+',
                              default=[],
                              help='One or more RegEx that match the names of the services(s) to check.')
+
+    parser.add_argument('-V', action='version', version='%(prog)s {}'.format(__version__))
 
     if len(args) == 0:
         parser.print_help()

--- a/release_process.md
+++ b/release_process.md
@@ -23,13 +23,13 @@
 1. CodeClimate doesn't show scary issues (need to modify analyized branch)
 1. Upload package to test repo
 
-        twine upload --user XXXX --repository-url https://test.pypi.org/legacy/ dist/check_docker-2.0.x.tar.gz
+        twine upload --repository testpypi dist/check_docker-2.0.x.tar.gz
 1. Check test project page for formatting
 
    https://test.pypi.org/project/check_docker/
 1. Upload package to prod repo
 
-        twine upload --user XXXX --repository-url https://upload.pypi.org/legacy/ dist/check_docker-2.0.x.tar.gz
+        twine upload -r pypi dist/check_docker-2.0.x.tar.gz
 1. Check project page for formatting
 
    https://pypi.org/project/check_docker/


### PR DESCRIPTION
Added -V flag to display version
Prevented --present form being used without specifying any containers
Now treat --present like a check in case anyone wants to only check presence
Cleared deprecation warning about invalid escape sequences
Added tests for pretty_time