### PR TITLE
Added --verbose flag to choose details level of output 

### DIFF
--- a/check_docker/check_docker.py
+++ b/check_docker/check_docker.py
@@ -860,6 +860,8 @@ def socketfile_permissions_failure(parsed_args):
 
 def print_results():
     messages_concat = '; '.join(messages)
+    if len(messages_concat) == 0:
+        messages_concat = 'OK'
     perfdata_concat = ' '.join(performance_data)
     if len(performance_data) > 0:
         print(messages_concat + '|' + perfdata_concat)

--- a/check_docker/check_docker.py
+++ b/check_docker/check_docker.py
@@ -84,6 +84,8 @@ threads = []
 # This is used during testing
 DISABLE_THREADING = False
 
+# How verbose should the output be
+VERBOSE = False
 
 # Hacked up urllib to handle sockets
 #############################################################################################
@@ -397,7 +399,8 @@ def set_rc(new_rc):
 
 def ok(message):
     set_rc(OK_RC)
-    messages.append('OK: ' + message)
+    if VERBOSE:
+        messages.append('OK: ' + message)
 
 
 def warning(message):
@@ -805,6 +808,13 @@ def process_args(args):
                         metavar='WARN:CRIT',
                         help='Container restart thresholds.')
 
+    # Verbose
+    parser.add_argument('--verbose',
+                        dest='verbose',
+                        default=None,
+                        action='store_true',
+                        help="Show more verbose output")
+
     parser.add_argument('-V', action='version', version='%(prog)s {}'.format(__version__))
 
     if len(args) == 0:
@@ -879,6 +889,10 @@ def perform_checks(raw_args):
     if no_checks_present(args):
         unknown("No checks specified.")
         return
+
+    if args.verbose == True:
+        global VERBOSE
+        VERBOSE = True
 
     # Here is where all the work happens
     #############################################################################################


### PR DESCRIPTION
As described in issue #49 I would like to suppress the OK messages (to more easily identify the containers having an issue) in check_docker.py

I've added the argument --verbose.
The OK message-parts are only put the message array if the --verbose argument is set.
Without the --verbose flag, the OK messages are suppressed.

Please not that I don't have experience with Python! So although the code seems to do exactly what I want/need (at least for --status check), I don't know if my code is sustainable. Please feel free to adjust the code to make it nicer. 
