### PR TITLE
prevent installation fail on certain python36 builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ check_swarm Usage
 Gotchas
 -------
 
--  When using check_docker with older versions of docker (I have seen 1.4 and 1.5) –status only supports ‘running’, ‘restarting’, and ‘paused’.
+-  When using check_docker with older versions of docker (I have seen 1.4 and 1.5) -status only supports 'running', 'restarting', and 'paused'.
 -  When using check_docker, if no container is specified, all containers are checked. Some containers may return critcal status if the selected check(s) require a running container.
 -  When using check_docker, --present cannot be used without --containers to indicate what to check the presence of.
 


### PR DESCRIPTION
using ubuntu:bionic as docker image for a project and trying to install
the module using pip3 or even cloning the repository, it can occur the
error:

    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-4vc7_b2d-build/setup.py", line 35, in <module>
        long_description=open('README.rst').read(),
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 6520: ordinal not in range(128)

the commit just sanitize in ascii the offending chars