### PR TITLE
Support Docker running under CGroups v1 and v2

### DIFF
--- a/check_docker/check_docker.py
+++ b/check_docker/check_docker.py
@@ -520,7 +520,14 @@ def check_memory(container, thresholds):
     inspection = get_stats(container)
 
     # Subtracting cache to match what `docker stats` does.
-    adjusted_usage = inspection['memory_stats']['usage'] - inspection['memory_stats']['stats']['total_cache']
+    adjusted_usage = inspection['memory_stats']['usage']
+    if 'total_cache' in inspection['memory_stats']['stats']:
+        # CGroups v1 - https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+        adjusted_usage -= inspection['memory_stats']['stats']['total_cache']
+    elif 'inactive_file' in inspection['memory_stats']['stats']:
+        # CGroups v2 - https://www.kernel.org/doc/Documentation/cgroup-v2.txt
+        adjusted_usage -= inspection['memory_stats']['stats']['inactive_file']
+
     if thresholds.units == '%':
         max = 100
         usage = int(100 * adjusted_usage / inspection['memory_stats']['limit'])


### PR DESCRIPTION
Docker supports either CGroups v1 or v2 and while running under v2 the memory stat details change slightly. To account for FS cache we need to subtract out `memory_stats.stats.inactive_file` instead of `memory_stats.stats.total_cache` under v1.

We found this despondency when running the latest `dockerd` on Debian Bullseye.