### PR TITLE
Manifest list patch

### DIFF
--- a/check_docker/check_docker.py
+++ b/check_docker/check_docker.py
@@ -520,7 +520,14 @@ def check_memory(container, thresholds):
     inspection = get_stats(container)
 
     # Subtracting cache to match what `docker stats` does.
-    adjusted_usage = inspection['memory_stats']['usage'] - inspection['memory_stats']['stats']['total_cache']
+    adjusted_usage = inspection['memory_stats']['usage']
+    if 'total_cache' in inspection['memory_stats']['stats']:
+        # CGroups v1 - https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+        adjusted_usage -= inspection['memory_stats']['stats']['total_cache']
+    elif 'inactive_file' in inspection['memory_stats']['stats']:
+        # CGroups v2 - https://www.kernel.org/doc/Documentation/cgroup-v2.txt
+        adjusted_usage -= inspection['memory_stats']['stats']['inactive_file']
+
     if thresholds.units == '%':
         max = 100
         usage = int(100 * adjusted_usage / inspection['memory_stats']['limit'])


### PR DESCRIPTION
This patch fixes problems with images which have multiple builds for different OS types and a manifest list, instead of a config entry in the "base" manifest.