### PR TITLE
Use python3 in Makefile explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: lint test
 
 lint:
-	python -m pylint check_docker/
+	python3 -m pylint check_docker/
 test:
 	py.test -v
 coverage:


### PR DESCRIPTION
Since this only works with python3 and some distros (debian) ship python3 with that name, this changes makes things a bit easier